### PR TITLE
add ws call

### DIFF
--- a/2-play-scala-seed/app/controllers/HomeController.scala
+++ b/2-play-scala-seed/app/controllers/HomeController.scala
@@ -4,6 +4,7 @@ import io.opentracing.util.GlobalTracer
 import javax.inject._
 import org.slf4j.LoggerFactory
 import play.api.mvc._
+import play.api.libs.ws._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -12,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * application's home page.
   */
 @Singleton
-class HomeController @Inject()(implicit ec: ExecutionContext) extends Controller {
+class HomeController @Inject()(ws: WSClient)(implicit ec: ExecutionContext) extends Controller {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -29,8 +30,9 @@ class HomeController @Inject()(implicit ec: ExecutionContext) extends Controller
   }
 
   def post = Action.async(parse.anyContent) { request =>
-    Future {
-      spanResult
+    val request: WSRequest = ws.url("http://localhost:9000/futureMap")
+    request.get().map { resp =>
+      Ok(resp.body)
     }
   }
 

--- a/2-play-scala-seed/build.sbt
+++ b/2-play-scala-seed/build.sbt
@@ -20,7 +20,8 @@ libraryDependencies ++= Seq(
   "io.opentracing" % "opentracing-api" % "0.31.0",
   "io.opentracing" % "opentracing-util" % "0.31.0",
   "com.datadoghq" % "dd-trace-ot" % datadogAgentVersion,
-  "com.datadoghq" % "dd-trace-api" % datadogAgentVersion
+  "com.datadoghq" % "dd-trace-api" % datadogAgentVersion,
+  ws
 )
 
 javaAgents += "com.datadoghq" % "dd-java-agent" % datadogAgentVersion


### PR DESCRIPTION
Testing steps are the same as in https://github.com/DataDog/dd-trace-java/issues/432.

Here's what I'm expecting:
```
[netty.request (/post)·········································································]
   [play.request (/post)·····································································]
     [netty.client.request (/futureMap)····················································]
       [netty.request (/futureMap)·······················································]
         [play.request (/futureMap)····················································]
```

Here's what I'm seeing:
```
[netty.request (/post)·········································································]
   [play.request (/post)·····································································]

[netty.client.request (/futureMap)····················································]
    [netty.request (/futureMap)···················································]
        [play.request (/futureMap)············································]
```

Concrete example:
```
[netty-event-loop-4] INFO datadog.trace.agent.common.writer.LoggingWriter - write(trace): [{"type":"web","error":0,"meta":{"http.status_code":"200","component":"netty","span.kind":"server","http.url":"http://localhost:9000/futureMap","peer.hostname":"localhost","env":"dev","peer.port":"63268","thread.name":"netty-event-loop-4","http.method":"GET","thread.id":"43","span.type":"web"},"metrics":{"_sampling_priority_v1":1},"duration":238937245,"service":"datadog_test_app","resource":"GET /futureMap","name":"netty.request","trace_id":1906132636734442357,"span_id":7934570933879547950,"parent_id":3722420891150619320,"start":1534548786806094194},{"type":"web","error":0,"meta":{"http.status_code":"200","component":"play-action","span.kind":"server","http.url":"/futureMap","env":"dev","thread.name":"application-akka.actor.default-dispatcher-2","http.method":"GET","thread.id":"19","span.type":"web"},"metrics":{},"duration":22808156,"service":"datadog_test_app","resource":"GET /futureMap","name":"play.request","trace_id":1906132636734442357,"span_id":3903775844067949739,"parent_id":7934570933879547950,"start":1534548786844394896}]
[AsyncHttpClient-2-1] INFO datadog.trace.agent.common.writer.LoggingWriter - write(trace): [{"type":"http","error":0,"meta":{"http.status_code":"200","component":"netty-client","span.kind":"client","http.url":"http://localhost:9000/futureMap","peer.hostname":"localhost","env":"dev","peer.port":"9000","thread.name":"AsyncHttpClient-2-1","http.method":"GET","thread.id":"24","span.type":"http"},"metrics":{"_sample_rate":1.0,"_sampling_priority_v1":1},"duration":293337079,"service":"datadog_test_app","resource":"GET /futureMap","name":"netty.client.request","trace_id":1906132636734442357,"span_id":3722420891150619320,"parent_id":0,"start":1534548786800072364}]
[netty-event-loop-3] INFO datadog.trace.agent.common.writer.LoggingWriter - write(trace): [{"type":"web","error":0,"meta":{"http.status_code":"200","component":"netty","span.kind":"server","http.url":"http://localhost:9000/post","peer.hostname":"localhost","env":"dev","peer.port":"63267","thread.name":"netty-event-loop-3","http.method":"POST","thread.id":"42","span.type":"web"},"metrics":{"_sample_rate":1.0,"_sampling_priority_v1":1},"duration":826629248,"service":"datadog_test_app","resource":"POST /post","name":"netty.request","trace_id":8657442848177665001,"span_id":7069598813491143503,"parent_id":0,"start":1534548786277900401},{"type":"web","error":0,"meta":{"http.status_code":"200","component":"play-action","span.kind":"server","http.url":"/post","env":"dev","thread.name":"application-akka.actor.default-dispatcher-3","http.method":"POST","thread.id":"20","span.type":"web"},"metrics":{},"duration":391234587,"service":"datadog_test_app","resource":"POST /post","name":"play.request","trace_id":8657442848177665001,"span_id":2287070465331032353,"parent_id":7069598813491143503,"start":1534548786712350595}]
```